### PR TITLE
fix(code): celsius calculation

### DIFF
--- a/angularnet-demo-app.client/src/app/services/weather.service.ts
+++ b/angularnet-demo-app.client/src/app/services/weather.service.ts
@@ -15,7 +15,7 @@ export class WeatherService {
     }
 
     let a = sum / count;
-    let b = ((a - 32) * 5) / 10;
+    let b = ((a - 32) * 5) / 9;
 
     return b;
   }


### PR DESCRIPTION
This pull request includes a small but important change to the `WeatherService` class in the `angularnet-demo-app.client/src/app/services/weather.service.ts` file. The change corrects the formula used for temperature conversion.

* [`angularnet-demo-app.client/src/app/services/weather.service.ts`](diffhunk://#diff-8ffd66a8a8ce2834be45e4587837fb6b422458020592f794fa425e3e55a0507eL18-R18): Corrected the formula for converting temperature from Fahrenheit to Celsius by changing the divisor from 10 to 9.